### PR TITLE
fix a condition in the case-when statement.

### DIFF
--- a/mrblib/hibari/app.rb
+++ b/mrblib/hibari/app.rb
@@ -25,7 +25,7 @@ module Hibari
                end
 
       case engine
-      when 'nginx' || 'apache'
+      when 'nginx', 'apache'
         Kernel.run(self)
       when 'h2o'
         self


### PR DESCRIPTION
Currently, in hibari/app.rb, a case-when statement with multi-value condition has an incorrect expression like following. From this, on mod_mruby, mruby-hibari goes wrong. 

``` ruby
case engine
when 'nginx' || 'apache'
  Kernel.run(self)
```

This PR fixes this point. 

``` ruby
case engine
when 'nginx', 'apache'
  Kernel.run(self)
```
